### PR TITLE
add_participant had bug when participant existed

### DIFF
--- a/lib/pipedrive/deal.rb
+++ b/lib/pipedrive/deal.rb
@@ -17,7 +17,7 @@ module Pipedrive
 
     def add_participant(opts = {})
       res = post "#{resource_path}/#{id}/participants", :body => opts
-      res.success? ? res['data']['id'] : bad_response(res, opts)
+      res.success? ? res.dig('data', 'id') || 'exists' : bad_response(res, opts)
     end
 
     def participants


### PR DESCRIPTION
it may come back as HTTP success but is not having id set. so we use dig() to save access data or return 'existed'